### PR TITLE
fix typo

### DIFF
--- a/.editconfig
+++ b/.editconfig
@@ -1,4 +1,4 @@
-oot = true
+root = true
 
 [*]
 indent_style = space


### PR DESCRIPTION
I found typo in `.editorconfig` and fix it.
